### PR TITLE
Avoid passing classes that are not typography tokens to the 'font' prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid passing classes that are not typography tokens to the `font` prop.
+
 ## [0.7.1] - 2019-06-07
 ### Changed
 - Make headers convert to html `<hx>` classes and not span.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Avoid passing classes that are not typography tokens to the `font` prop.
+- Avoid passing classes that are not color tokens to the `textColor` prop.
 
 ## [0.7.1] - 2019-06-07
 ### Changed

--- a/react/__mocks__/vtex.native-types/index.tsx
+++ b/react/__mocks__/vtex.native-types/index.tsx
@@ -1,9 +1,1 @@
-import { InjectedIntl } from 'react-intl'
-
-export const formatIOMessage = ({
-  id,
-  intl,
-}: {
-  id: string
-  intl: InjectedIntl
-}) => intl.formatMessage({ id })
+export const formatIOMessage = ({ id }: { id: string }) => id

--- a/react/__test__/index.test.tsx
+++ b/react/__test__/index.test.tsx
@@ -199,6 +199,7 @@ teste|abc
 
     expect(asFragment()).toMatchSnapshot()
   })
+
   it('should render with two different heading levels', () => {
     const component = render(
       <RichText
@@ -212,6 +213,7 @@ teste|abc
     expect(component).toBeDefined()
     expect(component.asFragment()).toMatchSnapshot()
   })
+
   it('should render list', () => {
     const component = render(
       <RichText
@@ -224,6 +226,15 @@ teste|abc
     )
     expect(component).toBeDefined()
     expect(component.asFragment()).toMatchSnapshot()
+  })
+
+  it('should sanitize the font prop', () => {
+    const typography = 't-heading-1'
+    const { container } = render(<RichText {...defaultProps} text="foo" font={`${typography} foo`} />)
+
+    const element = container.querySelector(`.${typography}`)
+
+    expect(element).toBeDefined()
   })
 })
 

--- a/react/__test__/index.test.tsx
+++ b/react/__test__/index.test.tsx
@@ -233,8 +233,21 @@ teste|abc
     const { container } = render(<RichText {...defaultProps} text="foo" font={`${typography} foo`} />)
 
     const element = container.querySelector(`.${typography}`)
+    const notFound = container.querySelector('.foo')
 
-    expect(element).toBeDefined()
+    expect(element).toBeTruthy()
+    expect(notFound).toBeFalsy()
+  })
+
+  it('should sanitize the textColor prop', () => {
+    const color = 'c-muted-1'
+    const { container } = render(<RichText {...defaultProps} text="foo" textColor={`${color} foo`} />)
+
+    const element = container.querySelector(`.${color}`)
+    const notFound = container.querySelector('.foo')
+
+    expect(element).toBeTruthy()
+    expect(notFound).toBeFalsy()
   })
 })
 

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -124,11 +124,25 @@ const sanitizeFont = (font: string) => {
 
   const first = font.split(' ')[0]
 
-  if (typography.indexOf(first) !== -1) {
+  if (typography.indexOf(first) === -1) {
+    return 'tbody'
+  }
+
+  return first
+}
+
+const sanitizeColor = (color: string) => {
+  if (!color) {
+    return 'c-on-base'
+  }
+
+  const first = color.split(' ')[0]
+
+  if (first.indexOf('c-') === 0) {
     return first
   }
 
-  return 't-body'
+  return 'c-on-base'
 }
 
 const RichText: FunctionComponent<Props> = ({
@@ -208,7 +222,7 @@ const RichText: FunctionComponent<Props> = ({
       className={`${generateBlockClass(
         styles.container,
         blockClass
-      )} flex ${alignToken} ${itemsToken} ${justifyToken} ${sanitizeFont(font)} ${textColor}`}
+      )} flex ${alignToken} ${itemsToken} ${justifyToken} ${sanitizeFont(font)} ${sanitizeColor(textColor)}`}
     >
       <div dangerouslySetInnerHTML={{ __html: html }} />
     </div>

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -104,6 +104,33 @@ const getTargetFromUrl = (url: string) => {
   return hastTargetBlank ? 'target=_blank' : ''
 }
 
+const typography = [
+  't-heading-1',
+  't-heading-2',
+  't-heading-3',
+  't-heading-4',
+  't-heading-5',
+  't-heading-6',
+  't-body',
+  't-small',
+  't-mini',
+  't-code',
+]
+
+const sanitizeFont = (font: string) => {
+  if (!font) {
+    return 't-body'
+  }
+
+  const first = font.split(' ')[0]
+
+  if (typography.indexOf(first) !== -1) {
+    return first
+  }
+
+  return 't-body'
+}
+
 const RichText: FunctionComponent<Props> = ({
   font,
   text,
@@ -174,13 +201,14 @@ const RichText: FunctionComponent<Props> = ({
     marked(formatIOMessage({ id: text, intl })),
     sanitizerConfig
   )
+
   return (
     <div
       id={htmlId}
       className={`${generateBlockClass(
         styles.container,
         blockClass
-      )} flex ${alignToken} ${itemsToken} ${justifyToken} ${font} ${textColor}`}
+      )} flex ${alignToken} ${itemsToken} ${justifyToken} ${sanitizeFont(font)} ${textColor}`}
     >
       <div dangerouslySetInnerHTML={{ __html: html }} />
     </div>


### PR DESCRIPTION
Today is possible to add any class to the rich-text component using the prop `font`.

Example:

```jsx
<RichText font="custom-class other-class" />
```

This PR sanitizes this string only allowing typography token values.