### PR TITLE
Fix usage of marked being shared across instances resulting in wrong …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue with wrong blockClass being applied.
 
 ## [0.7.8] - 2019-10-25
 ### Chore


### PR DESCRIPTION
…blockClass being applied

### How to reproduce the bug
1. Open https://gympassus.myvtex.com/equipment/cardio
2. Inspect the element:
![image](https://user-images.githubusercontent.com/284515/68877808-70533480-06e5-11ea-905e-ab9ae1d7b8c9.png)
3. Check that the class `vtex-rich-text-0-x-paragraph--track-order-link` is being applied when the blockClass of this element is `notification` and not `tracka-order-link`.



---


### How to test
1. Open https://breno--gympassus.myvtex.com/equipment/cardio
2. Inspect the same element:
![image](https://user-images.githubusercontent.com/284515/68877944-a1cc0000-06e5-11ea-904f-5f4e4f4f30c2.png)
3. Now the blockClass applied is `notification`: `vtex-rich-text-0-x-paragraph--notification`.

### Solution
The bug was caused due to the `marked` lib being shared across many different usages of this component, making it susceptible of side-effects from other component render.

The fix makes it set the options of `marked` on every render, so we guarantee that it's using the right set of the renderer.
