### PR TITLE
Add support for ordered list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for ordered list.
 
 ## [0.7.9] - 2019-11-14
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -146,7 +146,8 @@ Below, we describe the namespaces that are defined in the rich-text.
 | `table`         | [index](https://github.com/vtex-apps/rich-text/blob/master/react/index.tsx) | Token inserted in items that were marked as table during markdown conversion               |
 | `tableHead`     | [index](https://github.com/vtex-apps/rich-text/blob/master/react/index.tsx) | Token inserted in items that were marked as thead during markdown conversion               |
 | `tableBody`     | [index](https://github.com/vtex-apps/rich-text/blob/master/react/index.tsx) | Token inserted in items that were marked as tbody during markdown conversion               |
-| `list`          | [index](https://github.com/vtex-apps/rich-text/blob/master/react/index.tsx) | Token inserted in items that were marked as lists (`<ul>`) during markdown conversion      |
+| `list`          | [index](https://github.com/vtex-apps/rich-text/blob/master/react/index.tsx) | Token inserted in items that were marked as lists (`<ul>` or `<ol>`) during markdown conversion      |
+| `list--ordered` | [index](https://github.com/vtex-apps/rich-text/blob/master/react/index.tsx) | Token inserted in items that were marked as ordered lists (`<ol>`) during markdown conversion      |
 | `listItem`      | [index](https://github.com/vtex-apps/rich-text/blob/master/react/index.tsx) | Token inserted in items that were marked as list items (`<li>`) during markdown conversion |
 | `headingLevel1` | [index](https://github.com/vtex-apps/rich-text/blob/master/react/index.tsx) | Token inserted in items that were marked `<h1>` during markdown conversion                 |
 | `headingLevel2` | [index](https://github.com/vtex-apps/rich-text/blob/master/react/index.tsx) | Token inserted in items that were marked `<h2>` during markdown conversion                 |

--- a/react/__test__/__snapshots__/index.test.tsx.snap
+++ b/react/__test__/__snapshots__/index.test.tsx.snap
@@ -343,7 +343,7 @@ exports[`Rich text component should render list 1`] = `
         Teste 
       </p>
       <ul
-        class="list"
+        class="list "
       >
         <li
           class="listItem"
@@ -361,6 +361,41 @@ exports[`Rich text component should render list 1`] = `
           Item 3
         </li>
       </ul>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Rich text component should render ordered list 1`] = `
+<DocumentFragment>
+  <div
+    class="container flex tl items-start justify-start t-body c-on-base"
+  >
+    <div>
+      <p
+        class="lh-copy paragraph"
+      >
+        Teste 
+      </p>
+      <ol
+        class="list list--ordered"
+      >
+        <li
+          class="listItem"
+        >
+          Item 1
+        </li>
+        <li
+          class="listItem"
+        >
+          Item 2
+        </li>
+        <li
+          class="listItem"
+        >
+          Item 3
+        </li>
+      </ol>
     </div>
   </div>
 </DocumentFragment>

--- a/react/__test__/index.test.tsx
+++ b/react/__test__/index.test.tsx
@@ -228,6 +228,21 @@ teste|abc
     expect(component.asFragment()).toMatchSnapshot()
   })
 
+
+  it('should render ordered list', () => {
+    const component = render(
+      <RichText
+        {...defaultProps}
+        text={
+          `Teste \n 1. Item 1\n 2. Item 2\n 3. Item 3`
+        }
+        blockClass="home"
+      />
+    )
+    expect(component).toBeDefined()
+    expect(component.asFragment()).toMatchSnapshot()
+  })
+
   it('should sanitize the font prop', () => {
     const typography = 't-heading-1'
     const { container } = render(<RichText {...defaultProps} text="foo" font={`${typography} foo`} />)

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -28,6 +28,7 @@ const CSS_HANDLES = [
   'headingLevel5',
   'headingLevel6',
   'list',
+  'list--ordered',
   'listItem',
   'image'
 ] as const
@@ -93,7 +94,7 @@ interface VTEXIOComponent extends FunctionComponent<Props> {
 type RichTextCssHandles = CssHandles<typeof CSS_HANDLES>
 
 const sanitizerConfig = {
-  allowedTags: ['p', 'span', 'a', 'div', 'br', 'img', 'iframe', 'table', 'thead', 'tbody', 'tr', 'td', 'th', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'li'],
+  allowedTags: ['p', 'span', 'a', 'div', 'br', 'img', 'iframe', 'table', 'thead', 'tbody', 'tr', 'td', 'th', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li'],
   allowedAttributes: {
     a: ['class', 'href', 'title', 'target'],
     span: ['class'],
@@ -111,6 +112,7 @@ const sanitizerConfig = {
     h5: ['class'],
     h6: ['class'],
     ul: ['class'],
+    ol: ['class'],
     li: ['class'],
   },
   allowedSchemes: ['http', 'https', 'mailto', 'tel'],
@@ -252,7 +254,10 @@ const RichText: FunctionComponent<Props> = ({
       `<img class="${
       handles.image
       }" src="${href}" alt="${text}" ${title ? `title="${title}"` : ''} />`
-    renderer.current.list = (body: string) => `<ul class="${handles.list}">${body}</ul>`
+    renderer.current.list = (body: string, ordered: boolean) => {
+      const tag = ordered ? 'ol' : 'ul'
+      return `<${tag} class="${handles.list} ${ordered ? handles['list--ordered'] : ''}">${body}</${tag}>`
+    }
     renderer.current.listitem = (text: string) => `<li class="${handles.listItem}">${text}</li>`
   }
 


### PR DESCRIPTION
Add support for using ordered lists, example:

```
Teste \n 1. Item 1\n 2. Item 2\n 3. Item 3
```

Will be:

```html
<p class="lh-copy paragraph">
  Teste
</p>
<ol class="list list--ordered">
  <li class="listItem">
    Item 1
  </li>
  <li class="listItem">
    Item 2
  </li>
  <li class="listItem">
    Item 3
  </li>
</ol>
```