### PR TITLE
Remove unnecessary schema definition in RichText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `title` and `description` to `content` of the `rich-text` interface to make it show in the new CMS.
+
+### Removed
+- Unnecessary schema definition in `RichText`.
 
 ## [0.10.0] - 2020-05-19
 ### Added

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react'
 import { injectIntl, InjectedIntlProps } from 'react-intl'
 import marked, { Renderer } from 'marked'
-import { values, last, test } from 'ramda'
+import { last, test } from 'ramda'
 import escapeHtml from 'escape-html'
 import insane from 'insane'
 import { useCssHandles, CssHandles } from 'vtex.css-handles'
@@ -76,13 +76,6 @@ const defaultValues = {
   textPosition: textPositionTypes.TEXT_POSITION_LEFT.value,
   textAlignment: textAlignmentTypes.TEXT_ALIGNMENT_LEFT.value,
 }
-
-const getEnumValues = (
-  enumObject: Record<string, { value: string; name: string }>
-) => values(enumObject).map(({ value }) => value)
-const getEnumNames = (
-  enumObject: Record<string, { value: string; name: string }>
-) => values(enumObject).map(({ name }) => name)
 
 const safelyGetToken = (
   tokenMap: Record<string, string>,
@@ -380,49 +373,6 @@ const MemoizedRichText: VTEXIOComponent = memo(RichText)
 
 MemoizedRichText.schema = {
   title: 'admin/editor.rich-text.title',
-  description: 'admin/editor.rich-text.description',
-  type: 'object',
-  properties: {
-    textPosition: {
-      title: 'admin/editor.rich-text.textPosition.title',
-      description: 'admin/editor.rich-text.textPosition.description',
-      type: 'string',
-      enum: getEnumValues(textPositionTypes),
-      enumNames: getEnumNames(textPositionTypes),
-      default: defaultValues.textPosition,
-      isLayout: true,
-    },
-    textAlignment: {
-      title: 'admin/editor.rich-text.textAlignment.title',
-      description: 'admin/editor.rich-text.textAlignment.description',
-      type: 'string',
-      default: defaultValues.textAlignment,
-      enum: getEnumValues(textAlignmentTypes),
-      enumNames: getEnumNames(textAlignmentTypes),
-      isLayout: true,
-    },
-    font: {
-      title: 'admin/editor.rich-text.font.title',
-      description: 'admin/editor.rich-text.font.description',
-      type: 'string',
-      default: 't-body',
-      isLayout: true,
-    },
-    textColor: {
-      title: 'admin/editor.rich-text.textColor.title',
-      description: 'admin/editor.rich-text.textColor.description',
-      type: 'string',
-      default: 'c-on-base',
-      isLayout: true,
-    },
-    blockClass: {
-      title: 'admin/editor.rich-text.blockClass.title',
-      description: 'admin/editor.rich-text.blockClass.description',
-      type: 'string',
-      default: null,
-      isLayout: true,
-    },
-  },
 }
 
 export default injectIntl(MemoizedRichText)

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,6 +2,8 @@
   "rich-text": {
     "component": "index",
     "content": {
+      "title": "admin/editor.rich-text.title",
+      "description": "admin/editor.rich-text.description",
       "properties": {
         "text": {
           "title": "admin/editor.rich-text.text.title",


### PR DESCRIPTION
#### What problem is this solving?

* Add `title` and `description` to `content` of the `rich-text` interface
* Remove unnecessary schema definition of the rich-text component

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Link to site-editor still working with the changes](https://cmscomponents--storecomponents.myvtex.com/admin/cms/site-editor/about-us)
[Link to site-editor without the changes](https://storecomponents.myvtex.com/admin/cms/site-editor/about-us)
[Link to the new CMS, click on the plus button and add a rich-text](https://cmscomponents--storecomponents.myvtex.com/admin/app/new-cms/edit/new)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/nuRXXyy020kta/giphy.gif)
