### PR TITLE
Add integration with Doc Prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.10.2-beta] - 2020-07-15
 ### Added
 - Schema declaration and Doc Prop trigger.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.10.1] - 2020-07-09
 ### Added
 - `title` and `description` to `content` of the `rich-text` interface to make it show in the new CMS.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `title` and `description` to `content` of the `rich-text` interface to make it show in the new CMS.
+
+### Removed
+- Unnecessary schema definition in `RichText`.
 
 ## [0.10.0] - 2020-05-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.10.1] - 2020-07-09
+## [0.10.2-beta] - 2020-07-15
 ### Added
-- `title` and `description` to `content` of the `rich-text` interface to make it show in the new CMS.
+- Schema declaration and Doc Prop trigger.
 
 ### Removed
-- Unnecessary schema definition in `RichText`.
+- Handmade props table.
 
 ## [0.10.0] - 2020-05-19
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ Check the [documentation of Markdown Language](https://www.markdownguide.org/che
 }
 ```
 
-%PROPS=MemoizedRichText%
+%PROPS=index%
 
 ## Customization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,31 +60,7 @@ Check the [documentation of Markdown Language](https://www.markdownguide.org/che
 }
 ```
 
-| Prop name           | Type      | Description                                                                                 |
-| ------------------- | --------- | ------------------------------------------------------------------------------------------- |
-| `font`     | `String` \| `{desktop: String, tablet: String, mobile: String}` | Define the tachyon token to be used as font. Default: `t-body`    |
-| `textColor`     | `String` | Define the tachyon token to be used as text color. Default: `c-on-base`                                          |
-| `text`        | `String` | Text written in markdown language to be displayed              |
-| `textAlignment`  | `TextAlignmentEnum` | Control the text alignment inside component. Default: `"LEFT"`                                                                |
-| `textPosition`       | `TextPostionEnum` | Choose in which position of the component text will be displayed, left, center or right. Default: `"LEFT"`                                                           |
-| `blockClass`       | `String` | Unique class name to be appended to block classes. Default: ''                                                           |
-
-Here are the possible values of `TextPostionEnum`
-
-| Enum name | Enum value | Description |
-| --------- | ---- | ----------- |
-| Left | 'LEFT' | Text will be to the left. If `isFullModeStyle` is false, image will be on the right |
-| Center | 'CENTER' | Text will be in the center. Not applicable if `isFullModeStyle` is false. |
-| Right | 'RIGHT' | Text will be to the right. If `isFullModeStyle` is false, image will be on the left |
-
-Here are the possible values of `TextAlignmentEnum`
-
-| Enum name | Enum value | Description |
-| --------- | ---- | ----------- |
-| Left | 'LEFT' | Text alignment will be to the left. |
-| Center | 'CENTER' | Text alignment will be to the center. |
-| Right | 'RIGHT' | Text alignment will be to the right. |
-
+%PROPS=MemoizedRichText%
 
 ## Customization
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "rich-text",
-  "version": "0.10.2-beta",
+  "version": "0.10.1",
   "title": "Rich Text",
   "description": "Rich text component",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "rich-text",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "title": "Rich Text",
   "description": "Rich text component",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "rich-text",
-  "version": "0.10.1",
+  "version": "0.10.2-beta",
   "title": "Rich Text",
   "description": "Rich text component",
   "defaultLocale": "pt-BR",

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react'
 import { injectIntl, InjectedIntlProps } from 'react-intl'
 import marked, { Renderer } from 'marked'
-import { last, test } from 'ramda'
+import { values, last, test } from 'ramda'
 import escapeHtml from 'escape-html'
 import insane from 'insane'
 import { useCssHandles, CssHandles } from 'vtex.css-handles'
@@ -76,6 +76,14 @@ const defaultValues = {
   textPosition: textPositionTypes.TEXT_POSITION_LEFT.value,
   textAlignment: textAlignmentTypes.TEXT_ALIGNMENT_LEFT.value,
 }
+
+const getEnumValues = (
+  enumObject: Record<string, { value: string; name: string }>
+) => values(enumObject).map(({ value }) => value)
+
+const getEnumNames = (
+  enumObject: Record<string, { value: string; name: string }>
+) => values(enumObject).map(({ name }) => name)
 
 const safelyGetToken = (
   tokenMap: Record<string, string>,
@@ -373,6 +381,49 @@ const MemoizedRichText: VTEXIOComponent = memo(RichText)
 
 MemoizedRichText.schema = {
   title: 'admin/editor.rich-text.title',
+  description: 'admin/editor.rich-text.description',
+  type: 'object',
+  properties: {
+    textPosition: {
+      title: 'admin/editor.rich-text.textPosition.title',
+      description: 'admin/editor.rich-text.textPosition.description',
+      type: 'string',
+      enum: getEnumValues(textPositionTypes),
+      enumNames: getEnumNames(textPositionTypes),
+      default: defaultValues.textPosition,
+      isLayout: true,
+    },
+    textAlignment: {
+      title: 'admin/editor.rich-text.textAlignment.title',
+      description: 'admin/editor.rich-text.textAlignment.description',
+      type: 'string',
+      default: defaultValues.textAlignment,
+      enum: getEnumValues(textAlignmentTypes),
+      enumNames: getEnumNames(textAlignmentTypes),
+      isLayout: true,
+    },
+    font: {
+      title: 'admin/editor.rich-text.font.title',
+      description: 'admin/editor.rich-text.font.description',
+      type: 'string',
+      default: 't-body',
+      isLayout: true,
+    },
+    textColor: {
+      title: 'admin/editor.rich-text.textColor.title',
+      description: 'admin/editor.rich-text.textColor.description',
+      type: 'string',
+      default: 'c-on-base',
+      isLayout: true,
+    },
+    blockClass: {
+      title: 'admin/editor.rich-text.blockClass.title',
+      description: 'admin/editor.rich-text.blockClass.description',
+      type: 'string',
+      default: null,
+      isLayout: true,
+    },
+  },
 }
 
 export default injectIntl(MemoizedRichText)

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react'
 import { injectIntl, InjectedIntlProps } from 'react-intl'
 import marked, { Renderer } from 'marked'
-import { values, last, test } from 'ramda'
+import { last, test } from 'ramda'
 import escapeHtml from 'escape-html'
 import insane from 'insane'
 import { useCssHandles, CssHandles } from 'vtex.css-handles'
@@ -76,13 +76,6 @@ const defaultValues = {
   textPosition: textPositionTypes.TEXT_POSITION_LEFT.value,
   textAlignment: textAlignmentTypes.TEXT_ALIGNMENT_LEFT.value,
 }
-
-const getEnumValues = (
-  enumObject: Record<string, { value: string; name: string }>
-) => values(enumObject).map(({ value }) => value)
-const getEnumNames = (
-  enumObject: Record<string, { value: string; name: string }>
-) => values(enumObject).map(({ name }) => name)
 
 const safelyGetToken = (
   tokenMap: Record<string, string>,
@@ -380,49 +373,6 @@ const MemoizedRichText: VTEXIOComponent = memo(RichText)
 
 MemoizedRichText.schema = {
   title: 'admin/editor.rich-text.title',
-  description: 'admin/editor.rich-text.description',
-  type: 'object',
-  properties: {
-    textPosition: {
-      title: 'admin/editor.rich-text.textPosition.title',
-      description: 'admin/editor.rich-text.textPosition.description',
-      type: 'string',
-      enum: getEnumValues(textPositionTypes),
-      enumNames: getEnumNames(textPositionTypes),
-      default: defaultValues.textPosition,
-      isLayout: true,
-    },
-    textAlignment: {
-      title: 'admin/editor.rich-text.textAlignment.title',
-      description: 'admin/editor.rich-text.textAlignment.description',
-      type: 'string',
-      default: defaultValues.textAlignment,
-      enum: getEnumValues(textAlignmentTypes),
-      enumNames: getEnumNames(textAlignmentTypes),
-      isLayout: true,
-    },
-    font: {
-      title: 'admin/editor.rich-text.font.title',
-      description: 'admin/editor.rich-text.font.description',
-      type: 'string',
-      default: 't-body',
-      isLayout: true,
-    },
-    textColor: {
-      title: 'admin/editor.rich-text.textColor.title',
-      description: 'admin/editor.rich-text.textColor.description',
-      type: 'string',
-      default: 'c-on-base',
-      isLayout: true,
-    },
-    blockClass: {
-      title: 'admin/editor.rich-text.blockClass.title',
-      description: 'admin/editor.rich-text.blockClass.description',
-      type: 'string',
-      default: null,
-      isLayout: true,
-    },
-  },
 }
 
 export default injectIntl(MemoizedRichText)

--- a/react/package.json
+++ b/react/package.json
@@ -32,5 +32,5 @@
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.99.0/public/@types/vtex.render-runtime"
   },
-  "version": "0.10.0"
+  "version": "0.10.1"
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,6 +2,8 @@
   "rich-text": {
     "component": "index",
     "content": {
+      "title": "admin/editor.rich-text.title",
+      "description": "admin/editor.rich-text.description",
       "properties": {
         "text": {
           "title": "admin/editor.rich-text.text.title",


### PR DESCRIPTION
#### What problem is this solving?

Added integration with [Doc Prop](https://github.com/vtex-apps/doc-prop) via markdown placeholder and schema declaration.

#### How to test it?

https://juzon--appliancetheme.myvtex.com/docs/app/vtex.rich-text@0.10.4-beta/

#### Related to / Depends on

To be fully functional on the IO Docs, depends on the [PR](https://github.com/vtex-apps/docs-ui/pull/96) on Docs-UI.
