### PR TITLE
Remove description from schema to not show the component in the new CMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Remove description of `rich-text` schema to make it not available in the new CMS.
 
 ## [0.11.1] - 2020-09-29
 ### Changed

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,6 +1,5 @@
 {
   "admin/editor.rich-text.title": "Title of Rich Text component",
-  "admin/editor.rich-text.description": "Description of Rich Text component",
   "admin/editor.rich-text.text.title": "Title of text property",
   "admin/editor.rich-text.text.description": "Description of text property",
   "admin/editor.rich-text.textPosition.title": "Title of textPosition property",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,5 @@
 {
   "admin/editor.rich-text.title": "Rich Text",
-  "admin/editor.rich-text.description": "A component which displays text written in Markdown language",
   "admin/editor.rich-text.text.title": "Text",
   "admin/editor.rich-text.text.description": "Text in markdown language to be displayed",
   "admin/editor.rich-text.textPosition.title": "Text Position",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,6 +1,5 @@
 {
   "admin/editor.rich-text.title": "Rich Text",
-  "admin/editor.rich-text.description": "Un componente que muestra texto escrito en lenguaje Markdown.",
   "admin/editor.rich-text.text.title": "Texto",
   "admin/editor.rich-text.text.description": "Texto en el idioma de markdown que se mostrará",
   "admin/editor.rich-text.textPosition.title": "Posición del texto",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,5 @@
 {
   "admin/editor.rich-text.title": "Rich Text",
-  "admin/editor.rich-text.description": "Um componente com imagem e texto onde você pode escolher como apresentar seu conteúdo",
   "admin/editor.rich-text.text.title": "Texto",
   "admin/editor.rich-text.text.description": "Texto em linguagem markdown a ser mostrado",
   "admin/editor.rich-text.textPosition.title": "Posição do texto",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1476,13 +1476,6 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/ramda@^0.26.6":
-  version "0.26.44"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.26.44.tgz#70bb06f5ae60809dc83a3d804505ee3123443738"
-  integrity sha512-s0cj9rylWw+Ax/AnttCQzMrLZGq/OxAIZgrkRLK1QHJIF6Qabd0//acMCFM6+Xb8Bi8p8PkT2fqpaQveRju/kA==
-  dependencies:
-    ts-toolbelt "^6.3.3"
-
 "@types/react-test-renderer@*":
   version "16.9.3"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
@@ -4851,11 +4844,6 @@ ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
     tslib "^1.9.3"
-
-ts-toolbelt@^6.3.3:
-  version "6.15.5"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
-  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 tslib@^1.10.0, tslib@^1.9.3:
   version "1.13.0"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -3,7 +3,6 @@
     "component": "index",
     "content": {
       "title": "admin/editor.rich-text.title",
-      "description": "admin/editor.rich-text.description",
       "properties": {
         "text": {
           "title": "admin/editor.rich-text.text.title",


### PR DESCRIPTION
#### What problem is this solving?

This component is a base component of the store framework and should not appear in the new cms, since it doesn't have a container around it.

#### How to test it?

[Workspace](https://demo--marinbrasil.myvtex.com/)
[CMS URL](https://demo--marinbrasil.myvtex.com/admin/app/new-cms/landingPage/edit/new)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/pHWPC1N5IZGVTfRgsN/giphy.gif)
