### PR TITLE
Adjust type name

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,10 +66,10 @@ Check the [documentation of Markdown Language](https://www.markdownguide.org/che
 | `textColor`     | `String` | Define the tachyon token to be used as text color. Default: `c-on-base`                                          |
 | `text`        | `String` | Text written in markdown language to be displayed              |
 | `textAlignment`  | `TextAlignmentEnum` | Control the text alignment inside component. Default: `"LEFT"`                                                                |
-| `textPosition`       | `TextPostionEnum` | Choose in which position of the component text will be displayed, left, center or right. Default: `"LEFT"`                                                           |
+| `textPosition`       | `TextPositionEnum` | Choose in which position of the component text will be displayed, left, center or right. Default: `"LEFT"`                                                           |
 | `blockClass`       | `String` | Unique class name to be appended to block classes. Default: ''                                                           |
 
-Here are the possible values of `TextPostionEnum`
+Here are the possible values of `TextPositionEnum`
 
 | Enum name | Enum value | Description |
 | --------- | ---- | ----------- |


### PR DESCRIPTION
#### What problem is this solving?
Adjusting type name "TextPositionEnum" into rich-text component
<!--- What is the motivation and context for this change? -->

#### How to test it?
Just [go to docs](https://developers.vtex.com/vtex-developer-docs/docs/vtex-rich-text#rich-text) and see wrong word 
<!--- Don't forget to add a link to a Workspace where this branch is linked -->

#### Screenshots or example usage:
![image](https://user-images.githubusercontent.com/11761170/97017036-d7977c80-1523-11eb-9002-39934cf483b1.png)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

