### PR TITLE
Bump rich-text to 0.16.1 and align CHANGELOG above 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+# [Unreleased]
+### Changed
+- Documentation and actions/cache updates carried forward to 0.16.x.
+
+# [0.16.1] - 2025-10-03
+### Changed
+- Update docs/README.md.
+- Align release line above 0.16.0.
 
 ## [0.15.5] - 2025-10-03
-
 ### Changed
-
 - Update GitHub actions/cache to v4
 
 ## [0.15.4] - 2023-04-27

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "rich-text",
-  "version": "0.15.5",
+  "version": "0.16.1",
   "title": "Rich Text",
   "description": "Rich text component",
   "defaultLocale": "pt-BR",


### PR DESCRIPTION
#### What problem is this solving?

After merging the [PR 98](https://github.com/vtex-apps/rich-text/pull/98), the publish failed, even when trying locally. The error `App build failed with message: Cannot publish a version older than vtex.rich-text@0.16.0` suggests the VTEX App Registry already has `vtex.rich-text@0.16.0` recorded, rejecting any attempt to publish a version lower than the highest known one.

Although the repository’s changelog shows 0.15.5 as the latest, `vtex.rich-text@0.16.0` is already present, as we can see in the [#vtex-io-releases](https://vtex.slack.com/archives/CT98SSTU4/p1680014758550409) channel:

<img width="588" height="115" alt="image" src="https://github.com/user-attachments/assets/260c4bb0-c95d-4d96-907e-70dc357fd0c9" />

This PR bumps the app version to 0.16.1 and updates CHANGELOG.md to align above 0.16.0, unblocking the publish and deploy flow.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
